### PR TITLE
Reassign original skin within WindowGUI.cs

### DIFF
--- a/Runtime/WindowGUI.cs
+++ b/Runtime/WindowGUI.cs
@@ -43,8 +43,9 @@ namespace Nothke.ProtoGUI
 
         protected virtual void OnGUI()
         {
+            var originalSkin = GUI.skin;
             GUI.skin = skin;
-
+			
             // Clamp to screen edges
             if (windowRect.x < 0) windowRect.x = 0;
             if (windowRect.y < 10) windowRect.y = 0;
@@ -60,6 +61,9 @@ namespace Nothke.ProtoGUI
                 //mouse -= windowRect.position;
                 GUI.Label(new Rect(50, Screen.height - 80, 1000, 1000), windowTooltip);
             }
+			
+			// Assign original skin back to make sure other GUI elements do not use ProtoGUISkin
+			GUI.skin = originalSkin;
         }
 
         void WindowBase(int id)


### PR DESCRIPTION
This PR aims to fix the issue where ProtoGUI skin is used in other GUI elements. Screenshot of the issue below (see Unity debug log font):
![image](https://user-images.githubusercontent.com/34338817/109312455-c05cf880-784f-11eb-9268-995dc9af0879.png)

Screenshot after the fix:
![image](https://user-images.githubusercontent.com/34338817/109312879-3b261380-7850-11eb-8190-ada7e6a209d2.png)


Tested with Unity 2019.4.17f1